### PR TITLE
Add RustChain to DePIN Compute section

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Welcome to our [DePIN (Decentralized Physical Infrastructure Networks)](https://
 - [Livepeer](https://livepeer.org)
 - [Acurast](https://acurast.com/)
 - [Lilypad](https://lilypad.tech)
+- [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain that rewards vintage hardware. Old computers earn more than new ones.
 
 #### Storage
 


### PR DESCRIPTION
## Addition

Added **RustChain** to the Decentralized Server > Compute section.

### Why RustChain qualifies for DePIN

- **Proof-of-Antiquity consensus**: Novel PoA that rewards vintage/old hardware more than modern hardware
- **Hardware-anchored**: 6-check fingerprint verification ties mining to real physical machines
- **Decentralized compute**: Miners provide compute resources and earn RTC tokens
- **Active project**: 252+ beacons registered, active miner network
- **Open source**: https://github.com/Scottcjn/Rustchain

### Entry added
```
- [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain that rewards vintage hardware. Old computers earn more than new ones.
```

Thanks for maintaining this awesome list!