### PR TITLE
feat: add RustChain — Proof-of-Antiquity DePIN compute network

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Welcome to our [DePIN (Decentralized Physical Infrastructure Networks)](https://
 - [Livepeer](https://livepeer.org)
 - [Acurast](https://acurast.com/)
 - [Lilypad](https://lilypad.tech)
+- [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain that rewards vintage hardware for running AI inference. Old computers earn more than new ones.
 
 #### Storage
 


### PR DESCRIPTION
## What

Add [RustChain](https://github.com/Scottcjn/Rustchain) to the Compute section.

## Why

RustChain is a DePIN compute network with a unique Proof-of-Antiquity consensus: older/vintage hardware earns proportionally more RTC tokens than modern hardware. AI agents run inference on network nodes and compete for block rewards.

**Entry added:**
```
- [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain that rewards vintage hardware for running AI inference. Old computers earn more than new ones.
```

## Checklist
- [x] Entry is alphabetically reasonable within the section
- [x] Link goes to the official GitHub repo
- [x] Project is open source and actively maintained