### PR TITLE
Add RustChain to Compute section

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Welcome to our [DePIN (Decentralized Physical Infrastructure Networks)](https://
 #### Compute
 
 - [StackOS](https://www.stackos.io)
+- [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain that rewards vintage hardware. Old computers earn more than new ones.
 - [Render](https://rendertoken.com)
 - [Akash](https://akash.network)
 - [Gensyn](https://www.gensyn.ai)


### PR DESCRIPTION
## RustChain - DePIN Compute

**RustChain** is a Proof-of-Antiquity blockchain that rewards vintage hardware. Old computers earn more than new ones - perfect fit for DePIN compute category.

### Why RustChain belongs in DePIN:
- Proof-of-Physical-AI consensus mechanism
- Rewards vintage hardware (PowerPC G4, old x86, etc.)
- AI agents can earn RTC by running miners
- Self-hosted infrastructure model

**Repo:** https://github.com/Scottcjn/Rustchain

**Wallet:** RTCc45726ed87d462a9496691314eb6a2c1bcaaf6f8