### PR TITLE
Add RustChain to Compute category

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Welcome to our [DePIN (Decentralized Physical Infrastructure Networks)](https://
 - [Livepeer](https://livepeer.org)
 - [Acurast](https://acurast.com/)
 - [Lilypad](https://lilypad.tech)
+- [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain that rewards vintage hardware. Old computers earn more than new ones.
+
 - [RustChain](https://github.com/Scottcjn/RustChain) - AI-Augmented Proof of Real Machines. DePIN for vintage hardware where old computers outearn new ones.
 
 #### Storage

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Welcome to our [DePIN (Decentralized Physical Infrastructure Networks)](https://
 - [Livepeer](https://livepeer.org)
 - [Acurast](https://acurast.com/)
 - [Lilypad](https://lilypad.tech)
+- [RustChain](https://github.com/Scottcjn/RustChain) - AI-Augmented Proof of Real Machines. DePIN for vintage hardware where old computers outearn new ones.
 
 #### Storage
 


### PR DESCRIPTION
## RustChain - DePIN Compute

Added RustChain to the Compute category as it provides decentralized compute through Proof-of-Antiquity consensus, rewarding vintage hardware owners for providing compute resources.

**RustChain** is a Proof-of-Antiquity blockchain that rewards vintage hardware. Old computers (PowerPC G4, ThinkPad, vintage servers) earn more than modern hardware, making it ideal for DePIN compute.

- [RustChain GitHub](https://github.com/Scottcjn/Rustchain)
- [elyanlabs.ai](https://elyanlabs.ai)