### PR TITLE
Add RustChain - Proof-of-Antiquity DePIN Compute

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Welcome to our [DePIN (Decentralized Physical Infrastructure Networks)](https://
 - [Acurast](https://acurast.com/)
 - [Lilypad](https://lilypad.tech)
 
+- [RustChain](https://rustchain.org) - Proof-of-Antiquity blockchain. Older hardware earns higher mining rewards.
 #### Storage
 
 - [Filecoin](https://filecoin.io)


### PR DESCRIPTION
## RustChain Addition to Compute

**RustChain** - Proof-of-Antiquity blockchain that rewards vintage hardware for DePIN compute.

- Website: https://rustchain.org
- GitHub: https://github.com/Scottcjn/Rustchain

**Why RustChain fits:**
- DePIN (Decentralized Physical Infrastructure) compute network
- Rewards vintage hardware owners for providing compute resources
- Novel Proof-of-Antiquity consensus mechanism

---
**Wallet: chenzhizhuan**