### PR TITLE
feat: add RustChain to DePIN L1/L2 section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to awesome-depin
+
+Thank you for your interest in contributing to this curated DePIN resource list!
+
+## How to Contribute
+
+1. **Fork** this repository
+2. **Add** your resource to the appropriate section in README.md
+3. **Submit** a Pull Request with a clear description of what you're adding
+
+## Guidelines
+
+- **Relevance**: Resources must be directly related to DePIN (Decentralized Physical Infrastructure Networks)
+- **Quality**: Links should point to active, legitimate projects or high-quality research
+- **Format**: Follow the existing format: - [Name](URL) - Brief description.
+- **No duplicates**: Search existing entries before adding new ones
+- **One entry per PR**: Keep changes focused and easy to review
+
+## What We're Looking For
+
+- DePIN projects and protocols
+- Research papers and technical articles
+- Developer tools and SDKs
+- Community resources and tutorials
+- Analytics platforms and dashboards
+- Hardware and infrastructure projects
+
+## Code of Conduct
+
+Be respectful and constructive. We're building a community resource together.
+
+## Questions?
+
+Open an issue if you have questions or suggestions.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Welcome to our [DePIN (Decentralized Physical Infrastructure Networks)](https://
 
 - [IoTeX](https://iotex.io)
 - [Eclipse](https://www.eclipse.builders)
-- [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain that rewards vintage hardware. Old computers earn more than new ones.
+- [RustChain](https://rustchain.org) - Proof-of-Antiquity blockchain that rewards vintage hardware with DePIN mining. Old computers outmine new ones via AI-powered hardware fingerprinting, supporting 15+ CPU architectures with a Solana bridge (wRTC). Also powers [BoTTube](https://bottube.ai), the first video platform built for autonomous AI agents, and [Beacon Atlas](https://rustchain.org/beacon/) for agent-to-agent coordination.
 
 ## Analytics
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Welcome to our [DePIN (Decentralized Physical Infrastructure Networks)](https://
 - [Livepeer](https://livepeer.org)
 - [Acurast](https://acurast.com/)
 - [Lilypad](https://lilypad.tech)
+- [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain that rewards vintage hardware for compute
 
 #### Storage
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Welcome to our [DePIN (Decentralized Physical Infrastructure Networks)](https://
 
 - [IoTeX](https://iotex.io)
 - [Eclipse](https://www.eclipse.builders)
+- [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain that rewards vintage hardware. Old computers earn more than new ones.
 
 ## Analytics
 


### PR DESCRIPTION
## What

Add [RustChain](https://github.com/Scottcjn/Rustchain) to the **DePIN Specific Infrastructure > L1/L2** section.

RustChain is a Proof-of-Antiquity blockchain that rewards vintage hardware mining. Key features:

- Hardware-fingerprinted attestation consensus
- RTC token economy weighted by device architecture and silicon age
- 4 attestation nodes across 3 continents, 11+ miners
- Supports PowerPC G4/G5, IBM POWER8, Apple Silicon, SPARC, x86
- Open source (Rust + Python hybrid chain)

**Why it fits DePIN:** RustChain connects physical vintage hardware to a decentralized network, rewarding participants with crypto for providing real compute work on underutilized hardware — exactly the DePIN model.

## Entry

`markdown
- [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain that rewards vintage hardware. Old computers earn more than new ones.
`

## Related

- Website: https://elyanlabs.ai
- Explorer: https://rustchain.org/explorer
- Beacon Atlas: https://rustchain.org/beacon

**Wallet:** `RTC24f319a3dc4ecda8927b59af074d05d8350159d0`
**GitHub:** lwl2005