### PR TITLE
Add Xandeum (Storage) and Pulsar Network (Analytics)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Welcome to our [DePIN (Decentralized Physical Infrastructure Networks)](https://
 - [Polybase](https://polybase.xyz)
 - [Tableland](https://tableland.xyz)
 - [Swarm](https://www.ethswarm.org/)
+- [Xandeum](https://www.xandeum.network)
 
 #### VPN
 
@@ -174,6 +175,7 @@ Welcome to our [DePIN (Decentralized Physical Infrastructure Networks)](https://
 - [wholovesburrito](https://wholovesburrito.com)
 - [CoinGecko](https://www.coingecko.com/en/categories/depin)
 - [DePINScan](https://depinscan.io/)
+- [Pulsar Network](https://pulsarnetwork.xyz)
   
 ## Articles 
 - [What is DePIN](https://iotex.io/blog/what-are-decentralized-physical-infrastructure-networks-depin/)


### PR DESCRIPTION
Adds two entries in the existing format: Xandeum (a decentralized storage network on Solana) under Storage, since it wasn't listed yet, and Pulsar Network (an independent, open-source dashboard/monitor for the Xandeum network) under Analytics. Thanks for maintaining this list!