### PR TITLE
Add SNTL to Analytics — Helium/Solana DePIN threat & anomaly intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Welcome to our [DePIN (Decentralized Physical Infrastructure Networks)](https://
 - [wholovesburrito](https://wholovesburrito.com)
 - [CoinGecko](https://www.coingecko.com/en/categories/depin)
 - [DePINScan](https://depinscan.io/)
+- [SNTL — Helium DePIN threat & anomaly intelligence (x402)](https://a2a.sntl.site)
   
 ## Articles 
 - [What is DePIN](https://iotex.io/blog/what-are-decentralized-physical-infrastructure-networks-depin/)


### PR DESCRIPTION
Adds **SNTL** to the **Analytics** section, alongside DePINScan / DePINDD.

SNTL is a live analytics & security-intelligence layer over the Helium DePIN network (on Solana): it ingests raw on-chain activity in real time, enriches it through an AI pipeline, and classifies network threats and anomalies across all 12 Helium program shards. Agents and analysts query it pay-per-use at $0.01 USDC over the x402 protocol — no signup, no API key.

- Live: https://a2a.sntl.site
- Agent card (A2A/x402): https://a2a.sntl.site/.well-known/agent-card.json

One bare-link entry, matching the Analytics section format. Happy to adjust placement or wording.